### PR TITLE
Add docs on Franklin deployment + imagery management

### DIFF
--- a/docs/efficient-imagery-management.md
+++ b/docs/efficient-imagery-management.md
@@ -147,6 +147,6 @@ You can run `gdalinfo data/cogified-vrt.tiff` to verify that we've recovered the
 overviews down to 208x212.
 
 Then, since Franklin creates mosaics from specific items, you can create a new
-item pointing to your COGified tiff, a new mosaic definition including only that
-item, and then point to the specific tile URL for that mosaic in the client
-program or interface.
+item pointing to your combined and COGified tiff, a new mosaic definition
+including only that item, and then point to the specific tile URL for that
+mosaic in the client program or interface.

--- a/docs/efficient-imagery-management.md
+++ b/docs/efficient-imagery-management.md
@@ -1,0 +1,134 @@
+# Efficient imagery management with COGs
+
+This document outlines the steps needed to prepare imagery for efficient tiling with COGs.
+It assumes you have access to a running Franklin instance and a GDAL version >= 3.0 available
+(this is necessary for access to the COG output driver, which we'll rely on in some examples below).
+In short, bigger (larger area) COGs are better and faster than collections of smaller COGs.
+
+## The cloud-optimized GeoTIFF model
+
+Cloud-optimized GeoTIFFs are at their core GeoTIFFs with special headers and a few requirements:
+
+- they are _internally tiled_, meaning contiguous chunks of the data are organized into tiles of the
+  imagery instead of strips
+- they have _overviews_, which are collections of lower resolution views of the data
+
+The special headers include pointers to exactly how far in the image you have to go to get to a
+specific tile in a specific overview.
+
+The cloud-optimized part refers to those headers and their efficiency in server settings that
+support HTTP Get range requests. A server can serve the `bar.tiff` resource at `http://foo.com/bar.tiff`,
+and `bar.tiff` is a COG, and the server supports range requests, then a client can:
+
+- make a metadata request to `bar.tiff` to read the metadata explaining where all of the specific tiles live
+- jump to the special part of `bar.tiff` that the client is interested in
+
+We relied on this capability in both Raster Foundry and Franklin to store source imagery in a format that's
+good for humans (it's just GeoTIFF! You can load it up in QGIS!) and good for the tiling service because it
+could read less data to serve a tile.
+
+## Mosaics of COGs
+
+The above works _really nicely_ for individual images. However, in the mosaic story it gets a little bit more
+complicated. A _mosaic_ here will refer to collections of GeoTIFFs or other imagery that should all be queried
+to determine what a visualization should look like. In this case, we'll work with one of Sentinel-2 images from
+the transition to Franklin demo.
+
+From the repo root, you can download it with the following bash command. You can skip the `AWS_PROFILE` step
+if your default profile is named `default`.
+
+```bash
+$ export AWS_PROFILE=a-profile-name
+$ mkdir data && aws --profile raster-foundry s3 cp \
+    s3://rasterfoundry-production-data-us-east-1/demo-cogs/s2-canary-islands-rgb-cog.tif \
+    ./data/
+```
+
+If you inspect that tiff with `gdalinfo`, you'll see some information about overviews at the bottom:
+
+```bash
+$ gdalinfo data/s2-canary-islands-rgb-cog.tif
+...
+Band 1 Block=256x256 Type=UInt16, ColorInterp=Gray
+  Overviews: 6656x6784, 3328x3392, 1664x1696, 832x848, 416x424, 208x212
+  Mask Flags: PER_DATASET ALPHA
+Band 2 Block=256x256 Type=UInt16, ColorInterp=Undefined
+  Overviews: 6656x6784, 3328x3392, 1664x1696, 832x848, 416x424, 208x212
+  Mask Flags: PER_DATASET ALPHA
+Band 3 Block=256x256 Type=UInt16, ColorInterp=Undefined
+  Overviews: 6656x6784, 3328x3392, 1664x1696, 832x848, 416x424, 208x212
+  Mask Flags: PER_DATASET ALPHA
+Band 4 Block=256x256 Type=UInt16, ColorInterp=Alpha
+  Overviews: 6656x6784, 3328x3392, 1664x1696, 832x848, 416x424, 208x212
+```
+
+These `Overviews: ` sections indicate the total size of the image in each overview. Each overview covers the same
+area, but at lower resolutions, and each is also tiled into 256x256 pixel tiles. The full resolution for this image
+is about 10m, so the overviews cover 20m, 40m, 80m, 160m, 320m, and 640m / pixel resolutions. If you request a TMS
+tile at a zoom level where a pixel is at or below 640m, a COG-friendly server can just read the 208x212 pixels for the last
+overview. That requires reading 44096 pixels.
+
+Now let's talk about what happens if we split this image up. We can divide this image up into a smaller images using
+the `gdal_retile.py` helper script. In this case, I split it up and COGified the splits in a single command.
+
+```bash
+$ mkdir data/retiled/ && \
+    gdal_retile.py \
+    -of COG \
+    -co COMPRESS=DEFLATE \
+    -ps 2500 2500 \
+    -targetDir ./data/retiled/ \
+    data/s2-canary-islands-rgb-cog.tif
+```
+
+This command will create a bunch of sections of the source tif that are COGified slices of the full tif. Let's inspect one
+of them:
+
+```bash
+$ gdalinfo data/retiled/s2-canary-islands-rgb-cog_1_1.tif
+...
+Band 1 Block=512x512 Type=UInt16, ColorInterp=Gray
+  Overviews: 1250x1250, 625x625, 312x312
+Band 2 Block=512x512 Type=UInt16, ColorInterp=Undefined
+  Overviews: 1250x1250, 625x625, 312x312
+Band 3 Block=512x512 Type=UInt16, ColorInterp=Undefined
+  Overviews: 1250x1250, 625x625, 312x312
+Band 4 Block=512x512 Type=UInt16, ColorInterp=Undefined
+  Overviews: 1250x1250, 625x625, 312x312
+```
+
+The source resolution hasn't changed, so now we have overviews for 20, 40, and 80 meters for the sides of each pixel.
+
+Let's consider the low zoom case where a single TMS tile request covers all of data andthe desired pixel size is
+about 640m. Assume that the source image is perfectly tiled in the sense that the tiles here cover exactly the same area.
+We have a 6x6 grid of tiles that contribute to the image. For each tile, the smallest overview we have is 312x312. The server
+will have to read all of that data and downsample it server-side by a factor of 8. So, for each of the 36 tiles, we have to read
+a 312x312 grid. Now, to create the same image as the single image case, we have to read 36 * 312 * 312 pixels, or 3,504,384 pixels.
+That's about 80x as much data as we had to read in the single image case, _and_ we have to do work after the read to resample the 
+imagery and combine the data from each tiff.
+
+## Managing imagery efficiently in Franklin
+
+This isn't to say that all mosaics are bad and you shouldn't use them. Sometimes mosaics make sense. However, if you find
+yourself in a situation where the server appears to be significantly slower than makes sense, one bit of recourse you can try is
+to combine some of the images that contribute at rest.
+
+You can combine COGs into larger COGs using `gdalbuildvrt` and `gdal_translate`.
+
+For example, any time you have several COGs in the same directory, you can run these three commands to get a single COG from all
+of the contributing images:
+
+```bash
+# build a virtual raster from the contributing rasters
+$ gdalbuildvrt data/output.vrt data/retiled/*.tif
+# add overviews using the default overview selection heuristics
+$ gdaladdo data/output.vrt
+# gather the data from all of the contributing rasters into a single larger COG
+$ gdal_translate -of COG -co COMPRESS=DEFLATE data/output.vrt data/cogified-vrt.tiff
+```
+
+You can run `gdalinfo data/cogified-vrt.tiff` to verify that we've recovered the overviews down to 208x212.
+
+Then, since Franklin creates mosaics from specific items, you can create a new item pointing to your COGified tiff,
+a new mosaic definition including only that item, and then point to the specific tile URL for that mosaic in the client
+program or interface.

--- a/docs/efficient-imagery-management.md
+++ b/docs/efficient-imagery-management.md
@@ -21,7 +21,7 @@ go to get to a specific tile in a specific overview.
 
 The cloud-optimized part refers to those headers and their efficiency in server
 settings that support HTTP Get range requests. A server can serve the `bar.tiff`
-resource at `http://foo.com/bar.tiff`, and `bar.tiff` is a COG, and the server
+resource at `http://foo.com/bar.tiff`. If `bar.tiff` is a COG, and the server
 supports range requests, then a client can:
 
 - make a metadata request to `bar.tiff` to read the metadata explaining where

--- a/docs/efficient-imagery-management.md
+++ b/docs/efficient-imagery-management.md
@@ -127,7 +127,7 @@ from each tiff.
 This isn't to say that all mosaics are bad and you shouldn't use them. Sometimes
 mosaics make sense. However, if you find yourself in a situation where the
 server appears to be significantly slower than makes sense, one bit of recourse
-you can try is to combine some of the images that contribute at rest.
+you can try is to combine some of the images that contribute.
 
 You can combine COGs into larger COGs using `gdalbuildvrt` and `gdal_translate`.
 

--- a/docs/efficient-imagery-management.md
+++ b/docs/efficient-imagery-management.md
@@ -1,41 +1,48 @@
 # Efficient imagery management with COGs
 
-This document outlines the steps needed to prepare imagery for efficient tiling with COGs.
-It assumes you have access to a running Franklin instance and a GDAL version >= 3.0 available
-(this is necessary for access to the COG output driver, which we'll rely on in some examples below).
-In short, bigger (larger area) COGs are better and faster than collections of smaller COGs.
+This document outlines the steps needed to prepare imagery for efficient tiling
+with COGs. It assumes you have access to a running Franklin instance and a GDAL
+version >= 3.0 available (this is necessary for access to the COG output driver,
+which we'll rely on in some examples below). In short, bigger (larger area) COGs
+are better and faster than collections of smaller COGs.
 
 ## The cloud-optimized GeoTIFF model
 
-Cloud-optimized GeoTIFFs are at their core GeoTIFFs with special headers and a few requirements:
+Cloud-optimized GeoTIFFs are at their core GeoTIFFs with special headers and a
+few requirements:
 
-- they are _internally tiled_, meaning contiguous chunks of the data are organized into tiles of the
-  imagery instead of strips
-- they have _overviews_, which are collections of lower resolution views of the data
+- they are _internally tiled_, meaning contiguous chunks of the data are
+  organized into tiles of the imagery instead of strips
+- they have _overviews_, which are collections of lower resolution views of the
+  data
 
-The special headers include pointers to exactly how far in the image you have to go to get to a
-specific tile in a specific overview.
+The special headers include pointers to exactly how far in the image you have to
+go to get to a specific tile in a specific overview.
 
-The cloud-optimized part refers to those headers and their efficiency in server settings that
-support HTTP Get range requests. A server can serve the `bar.tiff` resource at `http://foo.com/bar.tiff`,
-and `bar.tiff` is a COG, and the server supports range requests, then a client can:
+The cloud-optimized part refers to those headers and their efficiency in server
+settings that support HTTP Get range requests. A server can serve the `bar.tiff`
+resource at `http://foo.com/bar.tiff`, and `bar.tiff` is a COG, and the server
+supports range requests, then a client can:
 
-- make a metadata request to `bar.tiff` to read the metadata explaining where all of the specific tiles live
+- make a metadata request to `bar.tiff` to read the metadata explaining where
+  all of the specific tiles live
 - jump to the special part of `bar.tiff` that the client is interested in
 
-We relied on this capability in both Raster Foundry and Franklin to store source imagery in a format that's
-good for humans (it's just GeoTIFF! You can load it up in QGIS!) and good for the tiling service because it
-could read less data to serve a tile.
+We relied on this capability in both Raster Foundry and Franklin to store source
+imagery in a format that's good for humans (it's just GeoTIFF! You can load it
+up in QGIS!) and good for the tiling service because it could read less data to
+serve a tile.
 
 ## Mosaics of COGs
 
-The above works _really nicely_ for individual images. However, in the mosaic story it gets a little bit more
-complicated. A _mosaic_ here will refer to collections of GeoTIFFs or other imagery that should all be queried
-to determine what a visualization should look like. In this case, we'll work with one of Sentinel-2 images from
-the transition to Franklin demo.
+The above works _really nicely_ for individual images. However, in the mosaic
+story it gets a little bit more complicated. A _mosaic_ here will refer to
+collections of GeoTIFFs or other imagery that should all be queried to determine
+what a visualization should look like. In this case, we'll work with one of
+Sentinel-2 images from the transition to Franklin demo.
 
-From the repo root, you can download it with the following bash command. You can skip the `AWS_PROFILE` step
-if your default profile is named `default`.
+From the repo root, you can download it with the following bash command. You can
+skip the `AWS_PROFILE` step if your default profile is named `default`.
 
 ```bash
 $ export AWS_PROFILE=a-profile-name
@@ -62,14 +69,17 @@ Band 4 Block=256x256 Type=UInt16, ColorInterp=Alpha
   Overviews: 6656x6784, 3328x3392, 1664x1696, 832x848, 416x424, 208x212
 ```
 
-These `Overviews: ` sections indicate the total size of the image in each overview. Each overview covers the same
-area, but at lower resolutions, and each is also tiled into 256x256 pixel tiles. The full resolution for this image
-is about 10m, so the overviews cover 20m, 40m, 80m, 160m, 320m, and 640m / pixel resolutions. If you request a TMS
-tile at a zoom level where a pixel is at or below 640m, a COG-friendly server can just read the 208x212 pixels for the last
+These `Overviews: ` sections indicate the total size of the image in each
+overview. Each overview covers the same area, but at lower resolutions, and each
+is also tiled into 256x256 pixel tiles. The full resolution for this image is
+about 10m, so the overviews cover 20m, 40m, 80m, 160m, 320m, and 640m / pixel
+resolutions. If you request a TMS tile at a zoom level where a pixel is at or
+below 640m, a COG-friendly server can just read the 208x212 pixels for the last
 overview. That requires reading 44096 pixels.
 
-Now let's talk about what happens if we split this image up. We can divide this image up into a smaller images using
-the `gdal_retile.py` helper script. In this case, I split it up and COGified the splits in a single command.
+Now let's talk about what happens if we split this image up. We can divide this
+image up into a smaller images using the `gdal_retile.py` helper script. In this
+case, I split it up and COGified the splits in a single command.
 
 ```bash
 $ mkdir data/retiled/ && \
@@ -81,8 +91,8 @@ $ mkdir data/retiled/ && \
     data/s2-canary-islands-rgb-cog.tif
 ```
 
-This command will create a bunch of sections of the source tif that are COGified slices of the full tif. Let's inspect one
-of them:
+This command will create a bunch of sections of the source tif that are
+COGified slices of the full tif. Let's inspect one of them:
 
 ```bash
 $ gdalinfo data/retiled/s2-canary-islands-rgb-cog_1_1.tif
@@ -97,26 +107,32 @@ Band 4 Block=512x512 Type=UInt16, ColorInterp=Undefined
   Overviews: 1250x1250, 625x625, 312x312
 ```
 
-The source resolution hasn't changed, so now we have overviews for 20, 40, and 80 meters for the sides of each pixel.
+The source resolution hasn't changed, so now we have overviews for 20, 40, and
+80 meters for the sides of each pixel.
 
-Let's consider the low zoom case where a single TMS tile request covers all of data andthe desired pixel size is
-about 640m. Assume that the source image is perfectly tiled in the sense that the tiles here cover exactly the same area.
-We have a 6x6 grid of tiles that contribute to the image. For each tile, the smallest overview we have is 312x312. The server
-will have to read all of that data and downsample it server-side by a factor of 8. So, for each of the 36 tiles, we have to read
-a 312x312 grid. Now, to create the same image as the single image case, we have to read 36 * 312 * 312 pixels, or 3,504,384 pixels.
-That's about 80x as much data as we had to read in the single image case, _and_ we have to do work after the read to resample the 
-imagery and combine the data from each tiff.
+Let's consider the low zoom case where a single TMS tile request covers all of
+data andthe desired pixel size is about 640m. Assume that the source image is
+perfectly tiled in the sense that the tiles here cover exactly the same area. We
+have a 6x6 grid of tiles that contribute to the image. For each tile, the
+smallest overview we have is 312x312. The server will have to read all of that
+data and downsample it server-side by a factor of 8. So, for each of the 36
+tiles, we have to read a 312x312 grid. Now, to create the same image as the
+single image case, we have to read 36 * 312 * 312 pixels, or 3,504,384 pixels.
+That's about 80x as much data as we had to read in the single image case, _and_
+we have to do work after the read to resample the imagery and combine the data
+from each tiff.
 
 ## Managing imagery efficiently in Franklin
 
-This isn't to say that all mosaics are bad and you shouldn't use them. Sometimes mosaics make sense. However, if you find
-yourself in a situation where the server appears to be significantly slower than makes sense, one bit of recourse you can try is
-to combine some of the images that contribute at rest.
+This isn't to say that all mosaics are bad and you shouldn't use them. Sometimes
+mosaics make sense. However, if you find yourself in a situation where the
+server appears to be significantly slower than makes sense, one bit of recourse
+you can try is to combine some of the images that contribute at rest.
 
 You can combine COGs into larger COGs using `gdalbuildvrt` and `gdal_translate`.
 
-For example, any time you have several COGs in the same directory, you can run these three commands to get a single COG from all
-of the contributing images:
+For example, any time you have several COGs in the same directory, you can run
+these three commands to get a single COG from all of the contributing images:
 
 ```bash
 # build a virtual raster from the contributing rasters
@@ -127,8 +143,10 @@ $ gdaladdo data/output.vrt
 $ gdal_translate -of COG -co COMPRESS=DEFLATE data/output.vrt data/cogified-vrt.tiff
 ```
 
-You can run `gdalinfo data/cogified-vrt.tiff` to verify that we've recovered the overviews down to 208x212.
+You can run `gdalinfo data/cogified-vrt.tiff` to verify that we've recovered the
+overviews down to 208x212.
 
-Then, since Franklin creates mosaics from specific items, you can create a new item pointing to your COGified tiff,
-a new mosaic definition including only that item, and then point to the specific tile URL for that mosaic in the client
+Then, since Franklin creates mosaics from specific items, you can create a new
+item pointing to your COGified tiff, a new mosaic definition including only that
+item, and then point to the specific tile URL for that mosaic in the client
 program or interface.

--- a/docs/efficient-imagery-management.md
+++ b/docs/efficient-imagery-management.md
@@ -111,7 +111,7 @@ The source resolution hasn't changed, so now we have overviews for 20, 40, and
 80 meters for the sides of each pixel.
 
 Let's consider the low zoom case where a single TMS tile request covers all of
-data andthe desired pixel size is about 640m. Assume that the source image is
+data and the desired pixel size is about 640m. Assume that the source image is
 perfectly tiled in the sense that the tiles here cover exactly the same area. We
 have a 6x6 grid of tiles that contribute to the image. For each tile, the
 smallest overview we have is 312x312. The server will have to read all of that

--- a/docs/franklin-deployment.md
+++ b/docs/franklin-deployment.md
@@ -104,3 +104,11 @@ you should ensure that the related user has permission to read from s3. If the E
 configured, you can allow access to s3 from the instance by
 [creating an IAM instance profile](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-instance-access-s3-bucket/)
 with the appropriate permissions.
+
+## Performance monitoring
+
+The running Franklin service will consume CPU and memory on your EC2 instance. To see whether
+your instance has spare capacity, you can select your instance, then in the pane below the list of instances,
+select the "Monitoring" tab. CPU utilization is the first metric shown there. To monitor memory utilization,
+you'll need to use CloudWatch Metrics. If you need to do that and are unable, email someone from Azavea and they
+can walk you through how.

--- a/docs/franklin-deployment.md
+++ b/docs/franklin-deployment.md
@@ -1,0 +1,1 @@
+# Franklin deployment

--- a/docs/franklin-deployment.md
+++ b/docs/franklin-deployment.md
@@ -1,1 +1,106 @@
 # Franklin deployment
+
+This document will outline how to run Franklin on an EC2 instance with an already existing database.
+It will rely on a compose file that brings up a container running Franklin and another container running
+PostgreSQL with PostGIS. Franklin's database will run in a separate container to avoid possible version
+mismatches and the additional infrastructure overhead of resolving those, since I don't know what labeler
+runs on.
+
+The goal of this deployment doc is to walk you through:
+
+- bringing up a Franklin container and database container
+- verifying connectivity with the running Franklin instance
+
+The assumptions this guide is based on are:
+
+- DNS already exists to access services running on the EC2 instance over the internet
+- the existing labeler service is already accessible via https on the standard port (443)
+
+## Bringing up containers
+
+We can start with the `docker-compose` file that's almost identical to the one in the repo.
+That looks like this:
+
+```yaml
+version: '2.3'
+services:
+  database:
+    image: quay.io/azavea/postgis:3-postgres12.2-slim
+    environment:
+      - POSTGRES_USER=franklin
+      - POSTGRES_PASSWORD=franklin
+      - POSTGRES_DB=franklin
+    expose:
+      - 5432
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "franklin"]
+      interval: 3s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    command: postgres -c log_statement=all
+    restart: always
+  franklin:
+    image: quay.io/azavea/franklin:b83e39c
+    depends_on:
+      database:
+        condition: service_healthy
+    command:
+      - serve
+      - --with-transactions
+      - --with-tiles
+      - --run-migrations
+    volumes:
+      - ./:/opt/franklin/
+      - $HOME/.aws:/var/lib/franklin/.aws
+    environment:
+      - ENVIRONMENT=development
+      - DB_HOST=database.service.internal
+      - DB_NAME=franklin
+      - DB_USER=franklin
+      - DB_PASSWORD=franklin
+      - AWS_PROFILE=default
+      - AWS_REGION
+    links:
+      - database:database.service.internal
+    ports:
+      - "9090:9090"
+    restart: always
+```
+
+This compose file will create a Franklin service available on port 9090 and a database service
+that is not accessible on the host. The database service being accessible only in the docker
+network prevents port conflicts with the existing running database.
+
+You can save it in `$HOME/docker-compose.yml`, then run `docker-compose up -d` from `$HOME`.
+
+The difference between these services and the ones defined in the repository is the presence of
+`restart: always`. This should ensure that the services come up each time after rebooting the
+ec2 instance.
+
+## Verifying connectivity
+
+You should already have some kind of DNS that routes HTTP traffic to the EC2 instance if you're
+able to access the labeler application over the internet. We'll piggy-back on that rather than
+dealing up any new records. The first step to verifying connectivity is, from outside the ec2
+instance, trying to make a request to the root URL (`<host name>:9090/`), and troubleshooting.
+
+You can do the first step with `curl`:
+
+```
+curl https://<hostname>:9090
+```
+
+If that works (you'll know it worked if you see a nice JSON response), congratulations, you're
+done! If that doesn't, the first debugging step is
+to check the [security groups](https://console.aws.amazon.com/vpc/home?region=us-east-1#securityGroups:)
+that apply to the EC2 instance. That security group needs to allow inbound TCP connections on the port
+that Franklin is running on (9090, unless you change something in the compose file).
+
+If that works, but then after following the notebook steps documented in the
+[`stac-client/`](../stac-client) directory, you can't view imagery, then where Franklin is running might
+not have permission to read from s3. If the EC2 instance you've deployed into has AWS credentials configured,
+you should ensure that the related user has permission to read from s3. If the EC2 instance has no credentials
+configured, you can allow access to s3 from the instance by
+[creating an IAM instance profile](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-instance-access-s3-bucket/)
+with the appropriate permissions.


### PR DESCRIPTION
Overview
=====

This PR adds docs on Franklin deployment (🔜) and imagery management. The imagery management docs are focused on why lots of small COGs are so painful for serving mosaics. The deployment docs are (will be) focused on running Franklin in an EC2 instance with an existing PostgreSQL database.

- [Rendered imagery management docs](https://github.com/agroimpacts/imager/blob/doc/js/franklin-deploy-plus-imagery-mgmt-docs/docs/efficient-imagery-management.md)
- [Rendered deployment docs](https://github.com/agroimpacts/imager/blob/doc/js/franklin-deploy-plus-imagery-mgmt-docs/docs/franklin-deployment.md)

Testing
-----

- read the rendered versions, add comments to changed files here where I've been unclear / where you have more questions